### PR TITLE
Fix payment request listing filters

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -338,7 +338,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const offset = parseInt(req.query.offset as string) || 0;
       const status = req.query.status as string;
       
-      const requests = await storage.getPaymentRequestsWithCreators();
+      const requests = await storage.getPaymentRequestsWithCreators(
+        limit,
+        offset,
+        status,
+      );
       res.json(requests);
     } catch (error: any) {
       res.status(500).json({ message: error.message || 'Failed to fetch payment requests' });


### PR DESCRIPTION
## Summary
- support limit, offset, and status in `getPaymentRequestsWithCreators`
- pass query params from `/api/payment-requests` route

## Testing
- `npm run check` *(fails: TS18046 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684056463bbc832fa68fc320c7699be4